### PR TITLE
refactor(client): modulize context menu + ox_lib utilization

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -175,41 +175,6 @@ ESX.HashString = function(str)
     return input_map
 end
 
-if GetResourceState("esx_context") ~= "missing" then
-    function ESX.OpenContext(...)
-        exports["esx_context"]:Open(...)
-    end
-
-    function ESX.PreviewContext(...)
-        exports["esx_context"]:Preview(...)
-    end
-
-    function ESX.CloseContext(...)
-        exports["esx_context"]:Close(...)
-    end
-
-    function ESX.RefreshContext(...)
-       exports["esx_context"]:Refresh(...)
-    end
-else
-    function ESX.OpenContext()
-        print("[^1ERROR^7] Tried to ^5open^7 context menu, but ^5esx_context^7 is missing!")
-    end
-
-    function ESX.PreviewContext()
-        print("[^1ERROR^7] Tried to ^5preview^7 context menu, but ^5esx_context^7 is missing!")
-    end
-
-    function ESX.CloseContext()
-        print("[^1ERROR^7] Tried to ^5close^7 context menu, but ^5esx_context^7 is missing!")
-    end
-
-    function ESX.RefreshContext()
-        print("[^1ERROR^7] Tried to ^5Refresh^7 context menu, but ^5esx_context^7 is missing!")
-    end
-end
-
-
 ESX.RegisterInput = function(command_name, label, input_group, key, on_press, on_release)
     RegisterCommand(on_release ~= nil and "+" .. command_name or command_name, on_press, false)
     Core.Input[command_name] = on_release ~= nil and ESX.HashString("+" .. command_name) or ESX.HashString(command_name)

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -1041,7 +1041,7 @@ function ESX.ShowInventory()
 
             elements[#elements+1] = {
                 icon = 'fas fa-money-bill-wave',
-                title = ('%s: <span style="color:green;">%s</span>'):format(ESX.PlayerData.accounts[i].label, formattedMoney),
+                title = ('%s: %s'):format(ESX.PlayerData.accounts[i].label, formattedMoney),
                 count = ESX.PlayerData.accounts[i].money,
                 type = 'item_account',
                 value = ESX.PlayerData.accounts[i].name,

--- a/client/modules/context.lua
+++ b/client/modules/context.lua
@@ -150,7 +150,7 @@ function ESX.RefreshContext(elements, _)
 
     if not currentContextId then return end
     if currentContextId ~= contextData?.id then -- strict check whether the current context is opened through ESX.OpenContext or not
-        return print("[^3WARNING^7] Tried to ^5refresh^7 a context menu, that hasn't been opened through ^2ESX.OpenContext^7.")
+        return print("[^1ERROR^7] Tried to ^5refresh^7 a context menu that hasn't been opened through ^2ESX.OpenContext^7.")
     end
 
     local _contextData = contextData -- save the current context menu data since it will be nil once ESX.CloseContext is called

--- a/client/modules/context.lua
+++ b/client/modules/context.lua
@@ -98,6 +98,25 @@ local function generateOptions(elements, onSelect)
                     default = optionData.inputValue,
                     autosize = true
                 }
+            elseif optionData.inputType == "radio" then
+                local radioOptions, defaultValue = {}, nil
+                for _i = 1, #optionData.inputValues do
+                    local radioOptionData = optionData.inputValues[_i]
+                    defaultValue = defaultValue or (radioOptionData.value == optionData.inputValue or radioOptionData.value == optionData.inputPlaceholder or radioOptionData.value == -1) and radioOptionData.value
+                    radioOptions[_i] = {label = radioOptionData.text, value = radioOptionData.value}
+                end
+
+                inputDialogData[1] = {
+                    type = "select",
+                    label = optionData.name or optionData.title,
+                    options = radioOptions,
+                    description = optionData.description,
+                    placeholder = optionData.inputPlaceholder,
+                    icon = optionData.icon,
+                    required = true,
+                    default = defaultValue,
+                    clearable = true
+                }
             end
 
             local input = lib.inputDialog(optionData.title, inputDialogData, {allowCancel = true})

--- a/client/modules/context.lua
+++ b/client/modules/context.lua
@@ -111,15 +111,15 @@ end
 
 ---@param elements? table
 function ESX.RefreshContext(elements, _)
-    local currentContext = lib.getOpenContextMenu()
+    local currentContextId = lib.getOpenContextMenu()
 
-    if not currentContext or currentContext ~= contextData?.id then return end -- strict check whether the current context is opened through ESX.OpenContext or not
-
-    if elements then
-        contextData.options = generateOptions(elements, contextData.onSelect)
+    if not currentContextId then return end
+    if currentContextId ~= contextData?.id then -- strict check whether the current context is opened through ESX.OpenContext or not
+        return print("[^3WARNING^7] Tried to ^5refresh^7 a context menu, that hasn't been opened through ^2ESX.OpenContext^7.")
     end
 
-    lib.hideContext(true) Wait(0)
-    lib.registerContext(contextData)
-    lib.showContext(contextData.id)
+    local _contextData = contextData -- save the current context menu data since it will be nil once ESX.CloseContext is called
+
+    ESX.CloseContext() Wait(0)
+    ESX.OpenContext(nil, elements or _contextData.eles, _contextData.onSelect, _contextData.onClose, _contextData.canClose)
 end

--- a/client/modules/context.lua
+++ b/client/modules/context.lua
@@ -56,8 +56,11 @@ local contextData
 local function generateOptions(elements, onSelect)
     local options = {}
 
-    for i = 1, #elements do
-        local optionData = elements[i]
+    local isFirstElementUnselectable = elements[1]?.unselectable == true
+
+    for index = isFirstElementUnselectable and 2 or 1, #elements do
+        local optionData = elements[index]
+        local i = isFirstElementUnselectable and index-1 or index
         options[i] = optionData
         options[i].title = optionData.title
         options[i].description = optionData.description
@@ -81,7 +84,7 @@ function ESX.OpenContext(_, elements, onSelect, onClose, canClose)
     local options = generateOptions(elements, onSelect)
     contextData = {
         id = "esx:contextMenu",
-        title = "Menu",
+        title = elements[1]?.unselectable and elements[1]?.title or "Menu",
         options = options,
         eles = elements,     -- populate the table for backward-compatibility with esx_context
         onSelect = onSelect, -- populate the table for backward-compatibility with esx_context

--- a/client/modules/context.lua
+++ b/client/modules/context.lua
@@ -1,0 +1,49 @@
+local useEsxContext = false
+
+if useEsxContext then
+    ---@param position? string left | center | right
+    ---@param elements table
+    ---@param onSelect? function
+    ---@param onClose? function
+    ---@param canClose? boolean defaults to true
+    function ESX.OpenContext(position, elements, onSelect, onClose, canClose)
+        if not GetResourceState("esx_context"):find("start") then
+            return print("[^1ERROR^7] Tried to ^5open^7 context menu, but ^5esx_context^7 is not started!")
+        end
+
+        exports["esx_context"]:Open(position, elements, onSelect, onClose, canClose)
+    end
+
+    ---@param position string left | center | right
+    ---@param elements table
+    ---@param onSelect? function
+    ---@param onClose? function
+    ---@param canClose? boolean defaults to true
+    function ESX.PreviewContext(position, elements, onSelect, onClose, canClose)
+        if not GetResourceState("esx_context"):find("start") then
+            return print("[^1ERROR^7] Tried to ^5preview^7 context menu, but ^5esx_context^7 is not started!")
+        end
+
+        exports["esx_context"]:Preview(position, elements, onSelect, onClose, canClose)
+    end
+
+    function ESX.CloseContext(_)
+        if not GetResourceState("esx_context"):find("start") then
+            return print("[^1ERROR^7] Tried to ^5close^7 context menu, but ^5esx_context^7 is not started!")
+        end
+
+        exports["esx_context"]:Close()
+    end
+
+    ---@param position? string left | center | right
+    ---@param elements? table
+    function ESX.RefreshContext(elements, position)
+        if not GetResourceState("esx_context"):find("start") then
+            return print("[^1ERROR^7] Tried to ^5Refresh^7 context menu, but ^5esx_context^7 is not started!")
+        end
+
+        exports["esx_context"]:Refresh(elements, position)
+    end
+
+    return
+end

--- a/client/modules/context.lua
+++ b/client/modules/context.lua
@@ -63,9 +63,9 @@ local function generateOptions(elements, onSelect)
         local i = isFirstElementUnselectable and index-1 or index
         options[i] = lib.table.deepclone(optionData)
         options[i].title = optionData.title
-        options[i].description = optionData.description or (optionData.inputValue and tostring(optionData.inputValue)) -- this is really weird. sometime it works with number and sometimes doesnt!
-        options[i].metadata = (optionData.description and optionData.inputValue) and {
-            {label = "value", value = optionData.inputValue}
+        options[i].description = optionData.name and (("%s%s"):format(optionData.name, (optionData.inputValue and ": " .. optionData.inputValue) or "")) or (optionData.inputValue and tostring(optionData.inputValue)--[[sometime it works with number and sometimes doesnt!]])
+        options[i].metadata = optionData.description and {
+            {label = "description", value = optionData.description}
         }
         options[i].icon = optionData.icon
         options[i].disabled = optionData.disabled or optionData.unselectable
@@ -86,6 +86,17 @@ local function generateOptions(elements, onSelect)
                     default = tonumber(optionData.inputValue),
                     min = tonumber(optionData.inputMin),
                     max = tonumber(optionData.inputMax),
+                }
+            elseif optionData.inputType == "text" then
+                inputDialogData[1] = {
+                    type = "textarea",
+                    label = optionData.name or optionData.title,
+                    description = optionData.description,
+                    placeholder = optionData.inputPlaceholder,
+                    icon = optionData.icon,
+                    required = true,
+                    default = optionData.inputValue,
+                    autosize = true
                 }
             end
 

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -2,7 +2,7 @@ fx_version 'adamant'
 
 game 'gta5'
 
-description 'ES Overextended'
+description 'ESX Overextended'
 
 lua54 'yes'
 version '1.9.4'
@@ -20,39 +20,25 @@ server_scripts {
     '@oxmysql/lib/MySQL.lua',
     'config.logs.lua',
     'server/common.lua',
-    'server/modules/callback.lua',
-    'server/classes/player.lua',
-    'server/classes/overrides/*.lua',
+    'server/modules/*.lua',
+    'server/classes/**/*.lua',
     'server/functions.lua',
     'server/onesync.lua',
     'server/paycheck.lua',
-
     'server/main.lua',
     'server/commands.lua',
 
-    'common/modules/*.lua',
-    'common/functions.lua',
-    'server/modules/actions.lua',
-    'server/modules/npwd.lua'
+    'common/**/*.lua',
 }
 
 client_scripts {
     'client/common.lua',
     'client/functions.lua',
+    'client/modules/*.lua',
     'client/wrapper.lua',
-    'client/modules/callback.lua',
-
     'client/main.lua',
 
-    'common/modules/*.lua',
-    'common/functions.lua',
-
-    'common/functions.lua',
-    'client/modules/actions.lua',
-    'client/modules/death.lua',
-    'client/modules/npwd.lua',
-    'client/modules/scaleform.lua',
-    'client/modules/streaming.lua',
+    'common/**/*.lua',
 }
 
 ui_page {

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-<h1 align='center'>ESX Legacy</a></h1>
+<h1 align='center'>ESX Overextended</a></h1>
 <p align='center'><a href='https://documentation.esx-framework.org/legacy/installation'>Documentation</a></b></h5>
 
 <hr>


### PR DESCRIPTION
The opportunity for using esx_context instead of ox_lib context menu is still there if someone wants it...

Should provide extensive backward compatibility with esx_context, if not complete compatibility!