### PR TITLE
fix(client/seatShuffle): seat shuffle is now working

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -74,7 +74,7 @@ AddEventHandler("esx:playerLoaded", function(xPlayer, isNew, skin)
         lib.onCache('seat', function(seat)
             if (seat == 0) then
                 SetPedIntoVehicle(cache.ped, vehicle, 0)
-                SetPedConfigFlag(ESX.PlayerData.ped, 184, true)
+                SetPedConfigFlag(cache.ped, 184, true)
             end
         end)
     end

--- a/client/main.lua
+++ b/client/main.lua
@@ -71,9 +71,9 @@ AddEventHandler("esx:playerLoaded", function(xPlayer, isNew, skin)
     end
 
     if Config.DisableVehicleSeatShuff then
-        AddEventHandler("esx:enteredVehicle", function(vehicle, _, seat)
-            if seat == 0 then
-                SetPedIntoVehicle(ESX.PlayerData.ped, vehicle, 0)
+        lib.onCache('seat', function(seat)
+            if (seat == 0) then
+                SetPedIntoVehicle(cache.ped, vehicle, 0)
                 SetPedConfigFlag(ESX.PlayerData.ped, 184, true)
             end
         end)


### PR DESCRIPTION
Seat shuffle hasn't worked since esx:enteredVehicle is never triggered, instead I used lib.onCache() from ox_lib