### PR TITLE
feat(player/methods): allow the set method to be non-networked

### DIFF
--- a/meta.lua
+++ b/meta.lua
@@ -41,7 +41,7 @@
 ---@field getGroups fun(): table<string, integer | number>
 ---@field setGroup fun(newGroup?: string): boolean
 ---@field getGroup fun(): string
----@field set fun(key: string, value: any)
+---@field set fun(key: string, value: any, syncWithStatebag?: boolean)
 ---@field get fun(key?: string): any
 ---@field getAccounts fun(minimal?: boolean): table
 ---@field getAccount fun(accountName?: string): table?

--- a/server/classes/player/playerMethods.lua
+++ b/server/classes/player/playerMethods.lua
@@ -248,9 +248,12 @@ local xPlayerMethods     = {
     set = function(self)
         ---@param key string
         ---@param value any
-        return function(key, value) -- TODO: sync with client using safe event
+        ---@param syncWithStatebag? boolean
+        return function(key, value, syncWithStatebag) -- TODO: sync with client using safe event
             self.variables[key] = value
-            Player(self.source).state:set(key, value, true)
+            if syncWithStatebag ~= false then
+                Player(self.source).state:set(key, value, true)
+            end
         end
     end,
 


### PR DESCRIPTION
* Add an argument to the `set` method, enabling the retrieval of these values exclusively through the player on the server side (thereby avoiding the use of the statebag).

we need to specify networked to false 

```lua
local player = ESX.GetPlayerFromId(1)
player.set("test", 500) -- this will be networked
player.set("test1", 487, false) -- this won't be networked
```