### PR TITLE
refactor: dynamically load ESX attributes

### DIFF
--- a/client/common.lua
+++ b/client/common.lua
@@ -13,6 +13,10 @@ exports("getSharedObject", function()
     return ESX
 end)
 
+exports("getReference", function(index)
+    return ESX[index]
+end)
+
 function ESX.GetConfig() ---@diagnostic disable-line: duplicate-set-field
     return Config
 end

--- a/imports.lua
+++ b/imports.lua
@@ -1,16 +1,29 @@
-ESX = exports["es_extended"]:getSharedObject()
+local es_extended = "es_extended"
+local esxMT = {
+    __index = function(self, index)
+        local reference = exports[es_extended]:getReference(index)
+
+        rawset(self, index, reference)
+
+        return reference
+    end
+}
+
+ESX = setmetatable({}, esxMT)
 
 if not _VERSION:find("5.4") then
     return ESX.Trace("^1Lua 5.4 must be enabled in the resource manifest!^7", "error", true)
 end
 
-if not IsDuplicityVersion() then -- Only register these for the client
+if not IsDuplicityVersion() then -- Client
     AddEventHandler("esx:setPlayerData", function(key, val, last)
-        if GetInvokingResource() == "es_extended" then
+        if GetInvokingResource() == es_extended then
             ESX.PlayerData[key] = val
 
-            if _G.OnPlayerData then
-                _G.OnPlayerData(key, val, last)
+            local onPlayerData = _G.OnPlayerData --[[@as function?]]
+
+            if onPlayerData then
+                onPlayerData(key, val, last)
             end
         end
     end)
@@ -26,53 +39,56 @@ if not IsDuplicityVersion() then -- Only register these for the client
     end)
 
     AddEventHandler("esx:sharedObjectUpdated", function()
-        ESX = exports["es_extended"]:getSharedObject()
+        ESX = setmetatable({}, esxMT)
 
         collectgarbage("collect")
     end)
-else -- Only register these for the server
+else -- Server
+    local jobsMT = {
+        __index = function(self, index)
+            if not next(self) then self() end
+
+            return rawget(self, index)
+        end,
+        __call = function(self)
+            for key, data in pairs(ESX.GetJobs()) do
+                rawset(self, key, data)
+            end
+
+            return self
+        end,
+        __pairs = function(self)
+            if not next(self) then self() end
+
+            return next, self, nil ---@diagnostic disable-line: redundant-return-value
+        end
+    }
+    local groupsMT = {
+        __index = function(self, index)
+            if not next(self) then self() end
+
+            return rawget(self, index)
+        end,
+        __call = function(self)
+            for key, data in pairs(ESX.GetGroups()) do
+                rawset(self, key, data)
+            end
+
+            return self
+        end,
+        __pairs = function(self)
+            if not next(self) then self() end
+
+            return next, self, nil ---@diagnostic disable-line: redundant-return-value
+        end
+    }
+
     local function setupESX()
         local _GetPlayerFromId = ESX.GetPlayerFromId
 
-        ESX.Jobs = setmetatable({}, {
-            __index = function(self, index)
-                if not next(self) then self() end
+        ESX.Jobs = setmetatable({}, jobsMT)
 
-                return rawget(self, index)
-            end,
-            __call = function(self)
-                for key, data in pairs(ESX.GetJobs()) do
-                    rawset(self, key, data)
-                end
-
-                return self
-            end,
-            __pairs = function(self)
-                if not next(self) then self() end
-
-                return next, self, nil ---@diagnostic disable-line: redundant-return-value
-            end
-        })
-
-        ESX.Groups = setmetatable({}, {
-            __index = function(self, index)
-                if not next(self) then self() end
-
-                return rawget(self, index)
-            end,
-            __call = function(self)
-                for key, data in pairs(ESX.GetGroups()) do
-                    rawset(self, key, data)
-                end
-
-                return self
-            end,
-            __pairs = function(self)
-                if not next(self) then self() end
-
-                return next, self, nil ---@diagnostic disable-line: redundant-return-value
-            end
-        })
+        ESX.Groups = setmetatable({}, groupsMT)
 
         function ESX.GetPlayerFromId(playerId) ---@diagnostic disable-line: duplicate-set-field
             local xPlayer = _GetPlayerFromId(playerId)
@@ -90,19 +106,19 @@ else -- Only register these for the server
     do setupESX() end
 
     AddEventHandler("esx:jobsObjectRefreshed", function()
-        if ESX and ESX.Jobs then
-            ESX.Jobs = ESX.GetJobs()
+        if ESX and ESX.Jobs and next(ESX.Jobs) then -- check to see if ESX.Jobs is being used in this external resource or not
+            ESX.Jobs = setmetatable(ESX.GetJobs(), jobsMT)
         end
     end)
 
     AddEventHandler("esx:groupsObjectRefreshed", function()
-        if ESX and ESX.Groups then
-            ESX.Groups = ESX.GetGroups()
+        if ESX and ESX.Groups and next(ESX.Groups) then -- check to see if ESX.Groups is being used in this external resource or not
+            ESX.Groups = setmetatable(ESX.GetJobs(), groupsMT)
         end
     end)
 
     AddEventHandler("esx:sharedObjectUpdated", function()
-        ESX = exports["es_extended"]:getSharedObject()
+        ESX = setmetatable({}, esxMT)
 
         do setupESX() end
 

--- a/server/common.lua
+++ b/server/common.lua
@@ -19,6 +19,10 @@ exports("getSharedObject", function()
     return ESX
 end)
 
+exports("getReference", function(index)
+    return ESX[index]
+end)
+
 local function startDBSync()
     CreateThread(function()
         while true do


### PR DESCRIPTION
This change avoids loading all of ESX object properties and methods to every external resources. It only loads the required indices based on the resource usage. It minimizes the memory allocation...